### PR TITLE
Changed use of new Buffer()

### DIFF
--- a/lib/ber/reader.js
+++ b/lib/ber/reader.js
@@ -187,7 +187,7 @@ Reader.prototype.readString = function(tag, retbuf) {
 	this._offset = o;
 
 	if (this.length === 0)
-		return retbuf ? new Buffer(0) : '';
+		return retbuf ? Buffer.alloc(0) : '';
 
 	var str = this._buf.slice(this._offset, this._offset + this.length);
 	this._offset += this.length;

--- a/lib/ber/writer.js
+++ b/lib/ber/writer.js
@@ -41,7 +41,7 @@ function merge(from, to) {
 function Writer(options) {
 	options = merge(DEFAULT_OPTS, options || {});
 
-	this._buf = new Buffer(options.size || 1024);
+	this._buf = Buffer.alloc(options.size || 1024);
 	this._size = this._buf.length;
 	this._offset = 0;
 	this._options = options;
@@ -302,7 +302,7 @@ Writer.prototype._ensure = function(len) {
 		if (sz - this._offset < len)
 			sz += len;
 
-		var buf = new Buffer(sz);
+		var buf = Buffer.alloc(sz);
 
 		this._buf.copy(buf, 0, 0, this._offset);
 		this._buf = buf;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asn1-ber",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "description": "Generate and parse ASN1.BER objects",
   "main": "index.js",
   "directories": {},


### PR DESCRIPTION
Changed use of new Buffer() to Buffer.alloc() to remedy warning of deprecation from Node.js 12.

Also, bumped version to 1.1.0.