### PR TITLE
Add write support for short OIDs

### DIFF
--- a/lib/ber/writer.js
+++ b/lib/ber/writer.js
@@ -177,7 +177,7 @@ Writer.prototype.writeOID = function(s, tag) {
 	if (typeof(tag) !== 'number')
 		tag = ASN1.OID;
 
-	if (!/^([0-9]+\.){3,}[0-9]+$/.test(s))
+	if (!/^([0-9]+\.){0,}[0-9]+$/.test(s))
 		throw new Error('argument is not a valid OID string');
 
 	function encodeOctet(bytes, octet) {


### PR DESCRIPTION
Hi @stephenwvickers - hope this finds you well!

The node-net-snmp agent needs to "reflect" received OIDs of any length, including those "short" OIDs (shorter than 4 parts to the address).

The current node-net-snmp solution is for the SNMP agent to somewhat incorrectly rewrite any reflected OIDs less than 4 parts to "1.3.6.1", just so that node-asn1-ber will write it without errors.  However, this violates RFC 3416, Section 4.2.1:
"All fields of the Response-PDU have the same values as the corresponding fields of the received request..."

A better solution is for the node-asn1-ber writer to enable writeOID to support OIDs shorter than length 4, hence this (1-character!) pull request.